### PR TITLE
Add Node.js LINE bot example

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@
     4. 下方則每 `5 分鐘` 打一次
     5. 按下 `CREATE`
 
+## Node.js 範例
+若想使用 JavaScript 建立簡易的 Line Bot，可參考倉庫根目錄的 `index.js`。此程式會回覆使用者傳來的文字。
+
+```bash
+node index.js
+```
+
+啟動後即可於 LINE 開發者後台設定 Webhook URL 進行測試。
+
 ## 指令
 在文字輸入框中直接輸入文字，即可與 ChatGPT 開始對話，而其他指令如下：
 

--- a/index.js
+++ b/index.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const { Client, middleware } = require('@line/bot-sdk');
+
+const config = {
+  channelAccessToken: process.env.LINE_CHANNEL_ACCESS_TOKEN,
+  channelSecret: process.env.LINE_CHANNEL_SECRET,
+};
+
+const app = express();
+app.use(express.json());
+app.use(middleware(config));
+
+const client = new Client(config);
+
+app.post('/webhook', (req, res) => {
+  Promise.all(req.body.events.map(handleEvent))
+    .then(() => res.status(200).end())
+    .catch((err) => {
+      console.error(err);
+      res.status(500).end();
+    });
+});
+
+async function handleEvent(event) {
+  if (event.type !== 'message' || event.message.type !== 'text') {
+    return Promise.resolve(null);
+  }
+  const replyText = `\u4f60\u8aaa\u7684\u662f：「${event.message.text}」`;
+  return client.replyMessage(event.replyToken, { type: 'text', text: replyText });
+}
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`LINE bot is running on port ${port}`);
+});
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "chatgpt-line-bot",
+  "version": "1.0.0",
+  "description": "Line bot example using Express and LINE Messaging API",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "test": "node index.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "MIT",
+  "type": "commonjs",
+  "dependencies": {
+    "@line/bot-sdk": "^7.5.2",
+    "express": "^4.19.2"
+  }
+}


### PR DESCRIPTION
## Summary
- add minimal Express + LINE Messaging API bot implementation
- document how to run the JavaScript echo bot

## Testing
- `npm test` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_688ed1ee89b4832b8a21ee64377dc717